### PR TITLE
Check the cb before calling on timeout.

### DIFF
--- a/httpinvoke-commonjs.js
+++ b/httpinvoke-commonjs.js
@@ -918,8 +918,10 @@ noData = function() {
                 xhr.timeout = timeout;
             } else {
                 setTimeout(function() {
+                  if (cb) { // May have been deleted.
                     cb(new Error('download timeout'));
                     cb = null;
+                  }
                 }, timeout);
             }
         }


### PR DESCRIPTION
I ran into this particular issue in some tests. It is an odd race condition, but it cropped up consistently. I note that you check the cb's existence in several places, just not this one.
