### PR TITLE
add browser field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,6 @@
     "node": "0.8 || 0.10 || 0.11"
   },
   "engineStrict": false,
-  "private": false
+  "private": false,
+  "browser": "./httpinvoke-browser.js"
 }


### PR DESCRIPTION
Allows for smaller builds via browserify. 

Currently browserify will pack up all the of the required modules it sees via static analysis, which includes `util` and `zlib`, making for very large builds.

https://github.com/substack/browserify-handbook#browser-field
